### PR TITLE
fix: delete event wrong revision

### DIFF
--- a/pkg/backends/btree/btree.go
+++ b/pkg/backends/btree/btree.go
@@ -18,7 +18,6 @@ package btree
 import (
 	"container/list"
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -259,10 +258,10 @@ func (b *btreeCache) Delete(ctx context.Context, key string, atRev int64) (int64
 	if err := b.index.Tombstone([]byte(key), rev); err != nil {
 		return b.currentRevision, nil, false, err
 	}
-	b.makeEvent(nil, &server.KeyValue{
+	b.makeEvent(&server.KeyValue{
 		Key:         key,
 		ModRevision: b.currentRevision,
-	}, true)
+	}, kv, true)
 
 	return b.currentRevision, kv, true, nil
 }
@@ -296,7 +295,6 @@ func (b *btreeCache) Watch(ctx context.Context, key string, startRevision int64)
 
 	pits := b.index.RangeSinceAll([]byte(key), []byte(getPrefixRangeEnd(key)), startRevision)
 	if len(pits) > 0 {
-		fmt.Println("-->", len(pits))
 		var events []*server.Event
 		for _, pit := range pits {
 			v := b.tree.Get(&item{
@@ -358,7 +356,7 @@ func (b *btreeCache) makeEvent(kv, prevKV *server.KeyValue, deleteEvent bool) {
 			Delete: true,
 			// Kine uses KV field to get the mod revision, so even for delete event,
 			// add the kv field.
-			KV:     prevKV,
+			KV:     kv,
 			PrevKV: prevKV,
 		}
 	} else {

--- a/pkg/etcdserver/kv.go
+++ b/pkg/etcdserver/kv.go
@@ -11,10 +11,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	DELETE_RANGE_LIMIT = 100000
-)
-
 func (k *EtcdServer) Range(ctx context.Context, r *etcdserverpb.RangeRequest) (*etcdserverpb.RangeResponse, error) {
 	var rev int64
 	etcdKvs := []*mvccpb.KeyValue{}

--- a/test/e2e/apisix/access_test.go
+++ b/test/e2e/apisix/access_test.go
@@ -33,7 +33,7 @@ var _ = Describe("APISIX", func() {
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "postman-echo.com:80": 1
+            "httpbin:80": 1
         }
     }
 }`
@@ -43,13 +43,14 @@ var _ = Describe("APISIX", func() {
     "upstream": {
         "type": "roundrobin",
         "nodes": {
-            "postman-echo.com:80": 1
+            "httpbin:80": 1
         }
     }
 }`
 	)
 
 	It("create route for the apisix, and access it", func() {
+		// create route
 		admin.PUT("/apisix/admin/routes/1").
 			WithHeader("X-API-KEY", "edd1c9f034335f136f87ad84b625c8f1").
 			WithBytes([]byte(createRoute1)).
@@ -81,5 +82,26 @@ var _ = Describe("APISIX", func() {
 
 		e.GET("/headers").Expect().Status(404)
 		e.GET("/get").Expect().Status(200)
+	})
+
+	It("delete route for the apisix, and access it", func() {
+		// create route
+		admin.PUT("/apisix/admin/routes/1").
+			WithHeader("X-API-KEY", "edd1c9f034335f136f87ad84b625c8f1").
+			WithBytes([]byte(createRoute1)).
+			Expect().Status(201)
+
+		time.Sleep(2 * time.Second)
+
+		e.GET("/headers").Expect().Status(200)
+
+		// delete route
+		admin.DELETE("/apisix/admin/routes/1").
+			WithHeader("X-API-KEY", "edd1c9f034335f136f87ad84b625c8f1").
+			Expect().Status(200)
+
+		time.Sleep(2 * time.Second)
+
+		e.GET("/headers").Expect().Status(404)
 	})
 })

--- a/test/testdata/apisix-adapter.docker-compose.yaml
+++ b/test/testdata/apisix-adapter.docker-compose.yaml
@@ -24,6 +24,14 @@ services:
       - "12379:12379/tcp"
     networks:
       - apisix
+  
+  httpbin:
+    image: kennethreitz/httpbin
+    restart: always
+    ports:
+      - "8080:80/tcp"
+    networks:
+      - apisix
 
 networks:
   apisix:


### PR DESCRIPTION
Even delete events need to record `mod_revision`


https://github.com/etcd-io/etcd/blob/217d183e5a2b2b7e826825f8218b8c4f53590a8f/server/mvcc/watchable_store_txn.go#L22-L47