### PR TITLE
fix: revision going lesser on restart

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,6 +29,11 @@ jobs:
         with:
           go-version: "1.20"
 
+      - uses: KengoTODA/actions-setup-docker-compose@v1
+        name: Set up Docker Compose
+        with:
+          version: '2.14.2' # the full version of `docker-compose` command
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,7 +37,10 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Install Ginkgo
-        run: go install github.com/onsi/ginkgo/v2/ginkgo@latest
+        run: |
+          GINKGO_VERSION=$(cd test/e2e && go list -m  -mod=readonly  -f {{.Version}}  github.com/onsi/ginkgo/v2)
+          go install github.com/onsi/ginkgo/v2/ginkgo@$GINKGO_VERSION
+          sudo cp ~/go/bin/ginkgo /usr/local/bin
 
       - name: Run test cases
         run: make e2e-test

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -41,8 +41,3 @@ jobs:
 
       - name: Run test cases
         run: make e2e-test
-
-      - name: Run tmate debugger
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15

--- a/pkg/backends/btree/btree.go
+++ b/pkg/backends/btree/btree.go
@@ -73,7 +73,7 @@ func (i *item) Less(j btree.Item) bool {
 // different goroutines.
 func NewBTreeCache() server.Backend {
 	return &btreeCache{
-		currentRevision: 1,
+		currentRevision: time.Now().UnixMilli(),
 		tree:            btree.New(32),
 		index:           newTreeIndex(),
 		events:          list.New(),

--- a/test/e2e/apisix/apisix_suite_test.go
+++ b/test/e2e/apisix/apisix_suite_test.go
@@ -31,7 +31,7 @@ func TestServer(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	cmd := exec.Command("docker-compose", "-f", "../../testdata/apisix-adapter.docker-compose.yaml", "up", "-d")
+	cmd := exec.Command("docker compose", "-f", "../../testdata/apisix-adapter.docker-compose.yaml", "up", "-d")
 	err := cmd.Run()
 	Expect(err).NotTo(HaveOccurred())
 	httpexpect.New(GinkgoT(), "http://127.0.0.1:9080").GET("").

--- a/test/e2e/apisix/apisix_suite_test.go
+++ b/test/e2e/apisix/apisix_suite_test.go
@@ -31,7 +31,7 @@ func TestServer(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	cmd := exec.Command("docker compose", "-f", "../../testdata/apisix-adapter.docker-compose.yaml", "up", "-d")
+	cmd := exec.Command("docker-compose", "-f", "../../testdata/apisix-adapter.docker-compose.yaml", "up", "-d")
 	err := cmd.Run()
 	Expect(err).NotTo(HaveOccurred())
 	httpexpect.New(GinkgoT(), "http://127.0.0.1:9080").GET("").


### PR DESCRIPTION
## Original Fix
As the starting revision in the btree backend here is 1. When used as stateless etcd, this causes issues as the revision goes back to 1 on restarts. This change ensure that future restarts, restart from a higher revision number.

## Subsequent change in kv.go etcd API handlers to fix the next issue described below after the above change
This is the sequence of function calls when a key is added
1-> [PUT called](https://github.com/api7/etcd-adapter/blob/0343aa7f6b71d1f74489e9637cfe5c090a3b5132/pkg/etcdserver/kv.go#L58) 
2-> [It tries to GET the key with revision=time.now()](https://github.com/api7/etcd-adapter/blob/0343aa7f6b71d1f74489e9637cfe5c090a3b5132/pkg/etcdserver/kv.go#L65) . The purpose of this will be cleared in next steps. Note that this revision doesn't exist but is a big number.
3-> [Get is called on Index](https://github.com/api7/etcd-adapter/blob/0343aa7f6b71d1f74489e9637cfe5c090a3b5132/pkg/backends/btree/btree.go#L94)
4-> [get calls findGeneration(rev)](https://github.com/api7/etcd-adapter/blob/0343aa7f6b71d1f74489e9637cfe5c090a3b5132/pkg/backends/btree/key_index.go#L142). Here rev is the time.now passed above.
5-> [here](https://github.com/api7/etcd-adapter/blob/0343aa7f6b71d1f74489e9637cfe5c090a3b5132/pkg/backends/btree/key_index.go#L293) it returns the generations containing the actual revision of the key if rev>actual revision. And previously starting from 1, the actual revision is always smaller than rev-which is time.now. So this flow was used to get the original revision.

The actual revision is then used to update the key.

When a value larger than time.Now()(in seconds) was used as starting value. findGeneration() on step 4 above returns "revision not found" because the actual rev in this case is bigger than the rev. This revision not found is suppressed [here](https://github.com/api7/etcd-adapter/blob/0343aa7f6b71d1f74489e9637cfe5c090a3b5132/pkg/backends/btree/btree.go#L97) ignoring this error and returning nil. And then this line is reached [etcd-adapter/pkg/backends/btree/btree.go at 0343aa7f6b71d1f74489e9637cfe5c090a3b5132 · api7/etcd-ada](https://github.com/api7/etcd-adapter/blob/0343aa7f6b71d1f74489e9637cfe5c090a3b5132/pkg/backends/btree/btree.go#L130). Causing the keyExists error

Short summary.
A large number (previously time.now) is used a revision initially to get the actual revision number. But this can only work if actual revision is smaller than the mock big number.


# Fix for the above issue.

Use math.MaxInt instead


When we used time.now.millisecond as initial value, the above functionality broke.

An end to end test is verified locally which will be added in the ingress controller repository to verify this fix.
![image](https://github.com/user-attachments/assets/2c4f410f-4bbd-4450-8e15-c1986c89d37d)





## Other fixes
In DeleteRange function, a nil check is added to avoid panic when a request to deleting a non existing key is sent. Now a valid response is returned like shown below:
![Screenshot from 2025-03-12 12-48-44](https://github.com/user-attachments/assets/1538e92e-c3fb-40fd-a594-2f2c69052624)


### No performance changes
```bash
 diff ./bench bench_change
5,16c5,16
< BenchmarkBTreeCacheGet/100_items-16           1000000000               0.0001875 ns/op
< BenchmarkBTreeCacheGet/5000_items-16          1000000000               0.0001830 ns/op
< BenchmarkBTreeCacheGet/20000_items-16         1000000000               0.0001513 ns/op
< BenchmarkBTreeCacheCreate/100_items-16        1000000000               0.0008868 ns/op
< BenchmarkBTreeCacheCreate/5000_items-16       1000000000               0.0009698 ns/op
< BenchmarkBTreeCacheCreate/20000_items-16      1000000000               0.001031 ns/op
< BenchmarkBTreeCacheList/100_items-16          1000000000               0.0001617 ns/op
< BenchmarkBTreeCacheList/5000_items-16         1000000000               0.0001029 ns/op
< BenchmarkBTreeCacheList/20000_items-16        1000000000               0.0001061 ns/op
< BenchmarkBTreeCacheDelete/100_items-16        1000000000               0.0000778 ns/op
< BenchmarkBTreeCacheDelete/5000_items-16       1000000000               0.0000378 ns/op
< BenchmarkBTreeCacheDelete/20000_items-16      1000000000               0.0000636 ns/op
---
> BenchmarkBTreeCacheGet/100_items-16           1000000000               0.0002112 ns/op
> BenchmarkBTreeCacheGet/5000_items-16          1000000000               0.0001734 ns/op
> BenchmarkBTreeCacheGet/20000_items-16         1000000000               0.0001506 ns/op
> BenchmarkBTreeCacheCreate/100_items-16        1000000000               0.001105 ns/op
> BenchmarkBTreeCacheCreate/5000_items-16       1000000000               0.0008509 ns/op
> BenchmarkBTreeCacheCreate/20000_items-16      1000000000               0.0009165 ns/op
> BenchmarkBTreeCacheList/100_items-16          1000000000               0.0003029 ns/op
> BenchmarkBTreeCacheList/5000_items-16         1000000000               0.0002673 ns/op
> BenchmarkBTreeCacheList/20000_items-16        1000000000               0.0002612 ns/op
> BenchmarkBTreeCacheDelete/100_items-16        1000000000               0.0002029 ns/op
> BenchmarkBTreeCacheDelete/5000_items-16       1000000000               0.0001278 ns/op
> BenchmarkBTreeCacheDelete/20000_items-16      1000000000               0.0000880 ns/op
18c18
< ok    github.com/api7/etcd-adapter/pkg/backends/btree 1.614s
---
> ok    github.com/api7/etcd-adapter/pkg/backends/btree 1.655s


```